### PR TITLE
Fix resources test

### DIFF
--- a/src/test/java/de/neemann/gui/language/ResourcesTest.java
+++ b/src/test/java/de/neemann/gui/language/ResourcesTest.java
@@ -20,6 +20,13 @@ public class ResourcesTest extends TestCase {
             "  <string name=\"menu_save\">Speichern</string>\n" +
             "  <string name=\"menu_open\">\u00D6ffnen</string>\n" +
             "</resources>";
+            
+    private static final String example2
+            = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                        "<resources>\n" +
+                        "  <string name=\"menu_open\">\u00D6ffnen</string>\n" +
+                        "  <string name=\"menu_save\">Speichern</string>\n" +
+                        "</resources>";
 
     public void testWrite() throws Exception {
         Resources res = new Resources();

--- a/src/test/java/de/neemann/gui/language/ResourcesTest.java
+++ b/src/test/java/de/neemann/gui/language/ResourcesTest.java
@@ -28,7 +28,7 @@ public class ResourcesTest extends TestCase {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         res.save(baos);
-        assertTrue(Arrays.equals(example.getBytes("utf-8"), baos.toByteArray()));
+        assertTrue(Arrays.equals(example.getBytes("utf-8"), baos.toByteArray()) || Arrays.equals(example2.getBytes("utf-8"), baos.toByteArray()));
     }
 
     public void testRead() throws Exception {

--- a/src/test/java/de/neemann/gui/language/ResourcesTest.java
+++ b/src/test/java/de/neemann/gui/language/ResourcesTest.java
@@ -23,10 +23,10 @@ public class ResourcesTest extends TestCase {
             
     private static final String example2
             = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                        "<resources>\n" +
-                        "  <string name=\"menu_open\">\u00D6ffnen</string>\n" +
-                        "  <string name=\"menu_save\">Speichern</string>\n" +
-                        "</resources>";
+            "<resources>\n" +
+            "  <string name=\"menu_open\">\u00D6ffnen</string>\n" +
+            "  <string name=\"menu_save\">Speichern</string>\n" +
+            "</resources>";
 
     public void testWrite() throws Exception {
         Resources res = new Resources();


### PR DESCRIPTION
Hi,

By running the following commands:
`mvn install -DskipTests`,
`mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=de.neemann.gui.language.ResourcesTest`,

`testWrite()` method fails sometimes. The reason is that `Resources()` class has a private HashMap `resourceMap`, which is passed as an object to `marshal` method of a `com.thoughtworks.xstream.XStream` object. Because the order of `resourceMap` is not deterministic, the XML output of `marshal` will not be deterministic either. 

I fixed the flaky test by comparing the actual output with all possible combinations of the output.